### PR TITLE
Fix fan cover 2 hidden despite fan count default

### DIFF
--- a/user_interface.py
+++ b/user_interface.py
@@ -123,6 +123,9 @@ class InputInitalValues(QWidget):
 
         self.fan_count_cb.currentIndexChanged.connect(self.update_fan_cover_visibility)
 
+        # 초기 팬 개수 설정에 맞춰 두 번째 팬 커버 가시성 업데이트
+        self.update_fan_cover_visibility()
+
         # 체크박스 데이터
         self.checkbox_states = {}
 


### PR DESCRIPTION
## Summary
- show second fan cover if fan count is set to 2 on startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859c6e4ef6083329253a6b5f9745ee6